### PR TITLE
close code block

### DIFF
--- a/material/domain.md
+++ b/material/domain.md
@@ -639,6 +639,7 @@ Actually, Haskell already has a function which does exactly this!
 ```haskell
 askMultiple :: [Question] -> IO [Answer]
 askMultiple = traverse ask
+```
 
 ---
 


### PR DESCRIPTION
Code block on slide "Actually, Haskell already has a function which does exactly this!" was missing closing quotes.